### PR TITLE
Fix bug with deprecated function usage of scypy.ndimage module

### DIFF
--- a/hasy/hasy_tools.py
+++ b/hasy/hasy_tools.py
@@ -272,7 +272,7 @@ def load_data(mode="fold-1", image_dim_ordering="tf"):
         for i, data_item in enumerate(data_csv):
             fname = os.path.join(untar_fpath, data_item["path"])
             s_compl.append(fname)
-            x_compl[i, 0, :, :] = imageio.imread(fname, flatten=False, pilmode="L")
+            x_compl[i, 0, :, :] = imageio.imread(fname, as_gray=False, pilmode="L")
             label = symbol_id2index[data_item["symbol_id"]]
             y_compl.append(label)
             path2index[fname] = i
@@ -414,10 +414,10 @@ def load_images(
         fname = os.path.join(dataset_path, data_item["path"])
         sources.append(fname)
         if flatten:
-            img = imageio.imread(fname, flatten=False, pilmode="L")
+            img = imageio.imread(fname, as_gray=False, pilmode="L")
             images[i, :] = img.flatten()
         else:
-            images[i, :, :, 0] = imageio.imread(fname, flatten=False, pilmode="L")
+            images[i, :, :, 0] = imageio.imread(fname, as_gray=False, pilmode="L")
         label = symbol_id2index[data_item["symbol_id"]]
         labels.append(label)
     # Make sure the type of images is float32
@@ -623,7 +623,7 @@ def _get_colors(data, verbose=False):
         if i % 1000 == 0 and i > 0 and verbose:
             print("%i of %i done" % (i, len(data)))
         fname = os.path.join(".", data_item["path"])
-        img = imageio.imread(fname, flatten=False, pilmode="L")
+        img = imageio.imread(fname, as_gray=False, pilmode="L")
         for row in img:
             for pixel in row:
                 color_count[pixel] += 1
@@ -814,7 +814,7 @@ def _inner_class_distance(data):
     mean_img = None
     for e1 in data:
         fname1 = os.path.join(".", e1["path"])
-        img1 = imageio.imread(fname1, flatten=False, pilmode="L")
+        img1 = imageio.imread(fname1, as_gray=False, pilmode="L")
         if mean_img is None:
             mean_img = img1.tolist()
         else:
@@ -824,7 +824,7 @@ def _inner_class_distance(data):
     scipy.misc.imshow(mean_img)
     for e1 in data:
         fname1 = os.path.join(".", e1["path"])
-        img1 = imageio.imread(fname1, flatten=False, pilmode="L")
+        img1 = imageio.imread(fname1, as_gray=False, pilmode="L")
         dist = _get_euclidean_dist(img1, mean_img)
         distances.append(dist)
 

--- a/hasy/hasy_tools.py
+++ b/hasy/hasy_tools.py
@@ -160,7 +160,7 @@ def _get_file(fname, origin, md5_hash=None, cache_subdir="~/.datasets"):
         if md5_hash is not None:
             if not _validate_file(fpath, md5_hash):
                 print(
-                   "A local file was found, but it seems to be "
+                    "A local file was found, but it seems to be "
                     "incomplete or outdated."
                 )
                 download = True
@@ -272,7 +272,7 @@ def load_data(mode="fold-1", image_dim_ordering="tf"):
         for i, data_item in enumerate(data_csv):
             fname = os.path.join(untar_fpath, data_item["path"])
             s_compl.append(fname)
-            x_compl[i, 0, :, :] = imageio.imread(fname, flatten=False, mode="L")
+            x_compl[i, 0, :, :] = imageio.imread(fname, flatten=False, pilmode="L")
             label = symbol_id2index[data_item["symbol_id"]]
             y_compl.append(label)
             path2index[fname] = i
@@ -414,10 +414,10 @@ def load_images(
         fname = os.path.join(dataset_path, data_item["path"])
         sources.append(fname)
         if flatten:
-            img = imageio.imread(fname, flatten=False, mode="L")
+            img = imageio.imread(fname, flatten=False, pilmode="L")
             images[i, :] = img.flatten()
         else:
-            images[i, :, :, 0] = imageio.imread(fname, flatten=False, mode="L")
+            images[i, :, :, 0] = imageio.imread(fname, flatten=False, pilmode="L")
         label = symbol_id2index[data_item["symbol_id"]]
         labels.append(label)
     # Make sure the type of images is float32
@@ -623,7 +623,7 @@ def _get_colors(data, verbose=False):
         if i % 1000 == 0 and i > 0 and verbose:
             print("%i of %i done" % (i, len(data)))
         fname = os.path.join(".", data_item["path"])
-        img = imageio.imread(fname, flatten=False, mode="L")
+        img = imageio.imread(fname, flatten=False, pilmode="L")
         for row in img:
             for pixel in row:
                 color_count[pixel] += 1
@@ -814,7 +814,7 @@ def _inner_class_distance(data):
     mean_img = None
     for e1 in data:
         fname1 = os.path.join(".", e1["path"])
-        img1 = imageio.imread(fname1, flatten=False, mode="L")
+        img1 = imageio.imread(fname1, flatten=False, pilmode="L")
         if mean_img is None:
             mean_img = img1.tolist()
         else:
@@ -824,7 +824,7 @@ def _inner_class_distance(data):
     scipy.misc.imshow(mean_img)
     for e1 in data:
         fname1 = os.path.join(".", e1["path"])
-        img1 = imageio.imread(fname1, flatten=False, mode="L")
+        img1 = imageio.imread(fname1, flatten=False, pilmode="L")
         dist = _get_euclidean_dist(img1, mean_img)
         distances.append(dist)
 

--- a/hasy/hasy_tools.py
+++ b/hasy/hasy_tools.py
@@ -23,7 +23,7 @@ from urllib.request import urlretrieve
 # Third party modules
 import matplotlib.pyplot as plt
 import numpy as np
-import scipy.ndimage
+import imageio
 from PIL import Image, ImageDraw
 from six.moves import urllib
 from six.moves.urllib.error import HTTPError, URLError
@@ -272,7 +272,7 @@ def load_data(mode="fold-1", image_dim_ordering="tf"):
         for i, data_item in enumerate(data_csv):
             fname = os.path.join(untar_fpath, data_item["path"])
             s_compl.append(fname)
-            x_compl[i, 0, :, :] = scipy.ndimage.imread(fname, flatten=False, mode="L")
+            x_compl[i, 0, :, :] = imageio.imread(fname, flatten=False, mode="L")
             label = symbol_id2index[data_item["symbol_id"]]
             y_compl.append(label)
             path2index[fname] = i

--- a/hasy/hasy_tools.py
+++ b/hasy/hasy_tools.py
@@ -160,7 +160,7 @@ def _get_file(fname, origin, md5_hash=None, cache_subdir="~/.datasets"):
         if md5_hash is not None:
             if not _validate_file(fpath, md5_hash):
                 print(
-                    "A local file was found, but it seems to be "
+                   "A local file was found, but it seems to be "
                     "incomplete or outdated."
                 )
                 download = True
@@ -414,10 +414,10 @@ def load_images(
         fname = os.path.join(dataset_path, data_item["path"])
         sources.append(fname)
         if flatten:
-            img = scipy.ndimage.imread(fname, flatten=False, mode="L")
+            img = imageio.imread(fname, flatten=False, mode="L")
             images[i, :] = img.flatten()
         else:
-            images[i, :, :, 0] = scipy.ndimage.imread(fname, flatten=False, mode="L")
+            images[i, :, :, 0] = imageio.imread(fname, flatten=False, mode="L")
         label = symbol_id2index[data_item["symbol_id"]]
         labels.append(label)
     # Make sure the type of images is float32
@@ -623,7 +623,7 @@ def _get_colors(data, verbose=False):
         if i % 1000 == 0 and i > 0 and verbose:
             print("%i of %i done" % (i, len(data)))
         fname = os.path.join(".", data_item["path"])
-        img = scipy.ndimage.imread(fname, flatten=False, mode="L")
+        img = imageio.imread(fname, flatten=False, mode="L")
         for row in img:
             for pixel in row:
                 color_count[pixel] += 1
@@ -814,7 +814,7 @@ def _inner_class_distance(data):
     mean_img = None
     for e1 in data:
         fname1 = os.path.join(".", e1["path"])
-        img1 = scipy.ndimage.imread(fname1, flatten=False, mode="L")
+        img1 = imageio.imread(fname1, flatten=False, mode="L")
         if mean_img is None:
             mean_img = img1.tolist()
         else:
@@ -824,7 +824,7 @@ def _inner_class_distance(data):
     scipy.misc.imshow(mean_img)
     for e1 in data:
         fname1 = os.path.join(".", e1["path"])
-        img1 = scipy.ndimage.imread(fname1, flatten=False, mode="L")
+        img1 = imageio.imread(fname1, flatten=False, mode="L")
         dist = _get_euclidean_dist(img1, mean_img)
         distances.append(dist)
 


### PR DESCRIPTION
It seems a function responsible for reading the dataset images is deprecated. I started this pull request to replace the said function to the recommended one (using imageio)

https://docs.scipy.org/doc/scipy-1.1.0/reference/generated/scipy.misc.imread.html#scipy.misc.imread
https://imageio.readthedocs.io/en/latest/scipy.html?highlight=flatten#transitioning-from-scipy-s-imread

I ask you to please review the code, probably I need to include `imageio` in the deps as well.
Thanks in advance.